### PR TITLE
Another fix for WIF key

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -19,6 +19,6 @@ module.exports = {
         },
         pubKeyHash: 0x64,
         scriptHash: 0x6e,
-        wif: 0xe4
+        wif: 0xef
     }
 }


### PR DESCRIPTION
Another fix for WIF key - Now the testnet. 

Actually is using the encoding for secretkey using the 228 (e4) and the TestNet for HTMLCoin uses 239 (ef) here https://github.com/HTMLCOIN/HTMLCOIN/blob/master-2.2/src/chainparams.cpp#L246

Now it will be compatible with the AltHash plataform and another web plataforms.